### PR TITLE
Remove transform-gpu on SVG'

### DIFF
--- a/src/app/(lobby)/page.tsx
+++ b/src/app/(lobby)/page.tsx
@@ -55,7 +55,7 @@ export default function Home() {
         <div className="relative isolate">
           <div
             aria-hidden="true"
-            className="pointer-events-none absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"
+            className="pointer-events-none absolute inset-x-0 -top-40 -z-10 overflow-hidden blur-3xl sm:-top-80"
           >
             <div
               style={{
@@ -86,7 +86,7 @@ export default function Home() {
 
           <div
             aria-hidden="true"
-            className="pointer-events-none absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"
+            className="pointer-events-none absolute inset-x-0 -top-40 -z-10 overflow-hidden blur-3xl sm:-top-80"
           >
             <div
               style={{


### PR DESCRIPTION
When the browser is not using hardware acceleration then the homepage lags extreamly on the top of the page.

Only tested through devtools in chrome, I have not run the code. I removed, what I removed in devtools to make it perform better. (Hint: I do not use hardware acceleration in my browser)